### PR TITLE
version update

### DIFF
--- a/fjdk.sh
+++ b/fjdk.sh
@@ -11,7 +11,7 @@
 # Repository:    https://github.com/src-rdgo/FlavoursJDK   (public)
 # Contact:       https://www.linkedin.com/in/rodrigolongueira/
 # Creation Date: 21/11/2025
-# Version:       1.0.0
+# Version:       1.0.1
 # Licença:       MIT
 # -----------------------------------------------------------------------------
 # docs:          readme.md
@@ -51,7 +51,7 @@ ICON_TREE_V="│"
 
 # Core Directories
 : "${FJDK_DIR:="$HOME/.fjdk"}"
-FJDK_VERSION="1.0.0"
+FJDK_VERSION="1.0.1"
 FJDK_VERSIONS_DIR="$FJDK_DIR/versions"
 FJDK_EXTERNAL_DIR="$FJDK_DIR/external"
 FJDK_CURRENT_LINK="$FJDK_DIR/current"


### PR DESCRIPTION
Change Log:
  1. Page size increased to 100 (enabled the script filter the wrong cases)
  2. kept the package_type=jdk, but the API sometimes ignores it for builds CRaC/Especials
  3. Smart filters 
        - download_url not null
        - file name must contain "jdk"
        - file name shouldn't contain "jre"
        - Get the first result from filtered list